### PR TITLE
Enable build S.R.WindowRuntime and mscorlib facade for .netcoreapp

### DIFF
--- a/src/System.Runtime.WindowsRuntime/ref/Configurations.props
+++ b/src/System.Runtime.WindowsRuntime/ref/Configurations.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       uap;
+      netcoreapp-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.WindowsRuntime/ref/Configurations.props
+++ b/src/System.Runtime.WindowsRuntime/ref/Configurations.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       uap;
-      netcoreapp-Windows_NT;
+      netcoreapp;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/System.Runtime.WindowsRuntime/src/Configurations.props
+++ b/src/System.Runtime.WindowsRuntime/src/Configurations.props
@@ -4,6 +4,7 @@
     <BuildConfigurations>
       uap-Windows_NT;
       uapaot-Windows_NT;
+      netcoreapp-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/mscorlib.WinRT-Facade/ref/Configurations.props
+++ b/src/mscorlib.WinRT-Facade/ref/Configurations.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       uap;
+      netcoreapp-Windows_NT;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>

--- a/src/mscorlib.WinRT-Facade/ref/Configurations.props
+++ b/src/mscorlib.WinRT-Facade/ref/Configurations.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <BuildConfigurations>
       uap;
-      netcoreapp-Windows_NT;
+      netcoreapp;
     </BuildConfigurations>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This will build these two assemblies for .netcoreapp